### PR TITLE
Refactor deployment to use Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use an appropriate base image
+FROM nginx:alpine
+
+# Copy the static files from the repository to the appropriate directory in the Docker image
+COPY . /usr/share/nginx/html
+
+# Expose the necessary port for the web server
+EXPOSE 80
+
+# Set the default command to run the web server
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -4,34 +4,35 @@ Calendar for New Media Releases
 ## Title of the Static Webpage
 The title of the static webpage is "Is that out yet?".
 
-## Hosting on Cloudflare Pages
-The static webpage is hosted on Cloudflare Pages.
-
 ## Deployment Instructions
 For detailed deployment instructions, please refer to the [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) file.
 
 ## Project Information
-This project is a basic static webpage with the title "Is that out yet?". It is hosted on Cloudflare Pages.
+This project is a basic static webpage with the title "Is that out yet?".
 
 ## How it Works
 The static webpage displays the title "Is that out yet?" in the browser. It is a simple HTML file with a `<title>` element and a `<h1>` element containing the text "Is that out yet?".
 
 ## Documentation
 For more information on how to run this application, please refer to the following documentation:
-- [Cloudflare Pages Documentation](https://developers.cloudflare.com/pages)
 - [HTML Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML)
 
 ## Deployment Documentation
 For detailed deployment instructions, please refer to the [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) file.
 
-## Future Features
-The following features are planned for future implementation:
-[] A calendar view to display upcoming media releases.
-[] Integration with external APIs to fetch release dates.
-[] Newsletter for users
-[] Discord alerts
-Support for different types of media releases, such as:
-    [] Movies....
-    [] TV Shows....
-    [] Video Games.
-    [] Comic Books.
+## Future Features and Tasks
+The following features and tasks are planned for future implementation:
+- [ ] A calendar view to display upcoming media releases.
+- [ ] Integration with external APIs to fetch release dates.
+- [ ] Newsletter for users
+- [ ] Discord alerts
+- [ ] Support for different types of media releases, such as:
+  - [ ] Movies
+  - [ ] TV Shows
+  - [ ] Video Games
+  - [ ] Comic Books
+- [ ] Securing the site with HTTPS
+- [ ] Using Kubernetes
+- [ ] Automated builds
+- [ ] Automated deploys to a container registry
+- [ ] Automated tests and PR checks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"
+    restart: always

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,18 +1,58 @@
 # Deployment Instructions
 
-## Setting up Cloudflare Pages
+## Setting up Docker on the Linux Instance
 
-1. Log in to your Cloudflare account.
-2. Go to the Cloudflare Pages dashboard.
-3. Click on "Create a project".
+1. Install Docker on your Linux instance by following the official Docker installation guide for your distribution.
+2. Start the Docker service and enable it to start on boot.
+3. Install Docker Compose by following the official Docker Compose installation guide.
 
-## Connecting the Repository to Cloudflare Pages
+## Building and Running the Docker Container using `docker-compose`
 
-1. Connect your GitHub repository to Cloudflare Pages.
-2. Select the repository and branch you want to deploy.
-3. Click "Begin setup".
+1. Clone the repository to your Linux instance:
+   ```
+   git clone https://github.com/MatthewGlenn/isthatoutyet.git
+   ```
+2. Navigate to the repository directory:
+   ```
+   cd isthatoutyet
+   ```
+3. Build and start the Docker container using Docker Compose:
+   ```
+   docker-compose up --build -d
+   ```
+4. The static webpage should now be accessible on port 80 of your Linux instance.
 
-## Deploying the Static Webpage
+## Removing the Docker Container
 
-1. Configure the build settings if necessary.
-2. Click "Save and Deploy".
+1. To stop and remove the Docker container, run:
+   ```
+   docker-compose down
+   ```
+
+## Updating the Docker Container
+
+1. To update the Docker container with the latest changes, pull the latest changes from the repository:
+   ```
+   git pull
+   ```
+2. Rebuild and restart the Docker container:
+   ```
+   docker-compose up --build -d
+   ```
+
+## Running Locally
+
+1. Install Docker and Docker Compose on your local machine.
+2. Clone the repository to your local machine:
+   ```
+   git clone https://github.com/MatthewGlenn/isthatoutyet.git
+   ```
+3. Navigate to the repository directory:
+   ```
+   cd isthatoutyet
+   ```
+4. Build and start the Docker container using Docker Compose:
+   ```
+   docker-compose up --build -d
+   ```
+5. The static webpage should now be accessible on port 80 of your local machine.


### PR DESCRIPTION
Add Docker support for deploying the application to a Linux instance on Linode or Akamai.

* **Dockerfile**: Create a `Dockerfile` to build the Docker image using `nginx:alpine` as the base image, copy static files, expose port 80, and set the default command to run the web server.
* **docker-compose.yml**: Create a `docker-compose.yml` file to manage the Docker container, define a service for the web server, specify the build context and Dockerfile, map ports, and set the container to restart automatically.
* **docs/DEPLOYMENT.md**: Update deployment instructions to include steps for setting up Docker on a Linux instance, building and running the Docker container using `docker-compose`, removing the Docker container, updating the Docker container, and running locally. Remove Cloudflare Pages deployment instructions.
* **README.md**: Update deployment method to reflect the new Docker-based deployment, provide a link to the updated deployment instructions, remove references to Cloudflare Pages, combine the future tasks and features section into a single section, update the future tasks and features section to use checkboxes, and refactor markdown.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MatthewGlenn/isthatoutyet?shareId=a85256d2-cd72-4a0d-a701-bc87c64e7ee8).