### PR TITLE
Add workflow step to update web server after pushing to main branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,3 +36,17 @@ jobs:
         platform: linux/amd64
         username: ${{ github.actor }}
         password: ${{ secrets.GH_PACKAGE_TOKEN }}
+    
+  update_web_server:
+    runs-on: ubuntu-latest
+    needs: push_to_registry
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      
+      - name: Update the web server
+        run: |
+          ssh -o StrictHostKeyChecking=no -i ${{ secrets.SSH_PRIVATE_KEY }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} './update-server.sh'


### PR DESCRIPTION
This PR introduces a new workflow step that automatically updates the web server whenever changes are pushed to the main branch. It sets up an SSH agent and executes a script on the server to perform the update, ensuring a seamless deployment process.